### PR TITLE
Fix HTTP request body close

### DIFF
--- a/internal/service/node/health.go
+++ b/internal/service/node/health.go
@@ -103,7 +103,6 @@ func (h *Health) check(ctx context.Context, rl <-chan struct{}, node service.Nod
 			h.Config.Logger.Error().Err(err).Msg("failed to create http request")
 			return nil
 		}
-		defer req.Body.Close() // nolint: errcheck
 		req = req.WithContext(ctx)
 
 		resp, err := h.Config.HTTPClient.Do(req)


### PR DESCRIPTION
The request don't have a body so we don't need to close it.